### PR TITLE
apply-patch: skip gemini-2.0-flash hunk headers in Add File blocks

### DIFF
--- a/codex-cli/src/utils/agent/apply-patch.ts
+++ b/codex-cli/src/utils/agent/apply-patch.ts
@@ -307,6 +307,8 @@ class Parser {
 
   private parse_add_file(): PatchAction {
     const lines: Array<string> = [];
+    // skip new-file hunk header (e.g. "@@ -0,0 +1@@" or "+1,NN@@")
+    const NEW_FILE_HUNK = /^@@\s+-0,0\s+\+1(?:,[1-9]\d*)?\s+@@/;
     while (
       !this.is_done([
         PATCH_SUFFIX,
@@ -316,6 +318,9 @@ class Parser {
       ])
     ) {
       const s = this.read_str();
+      if (NEW_FILE_HUNK.test(s)) {
+        continue;
+      }
       if (!s.startsWith(HUNK_ADD_LINE_PREFIX)) {
         throw new DiffError(`Invalid Add File Line: ${s}`);
       }


### PR DESCRIPTION
## What
Skip AI-generated hunk headers (e.g. @@-0,0+1@@) in Add File blocks.

## Why
Gemini-2.0-Flash emits those headers and apply_patch was throwing errors.

## How
Use /^@@\s*-0,0\s*\+1(?:,[1-9]\d*)?\s*@@/ to detect & skip them.

<details>
<summary>✅ CLA</summary>
I have read the CLA Document and I hereby sign the CLA
</details>